### PR TITLE
fixed opening plot

### DIFF
--- a/weak_values_GUI/server.py
+++ b/weak_values_GUI/server.py
@@ -1,6 +1,8 @@
 from flask import Flask, render_template, stream_template, request
 from weak_values import get_input_states, plot_weak_values, nroot_swap_weak_value_vectors
 from waitress import serve
+import os
+
 app = Flask(__name__)
 
 
@@ -79,7 +81,6 @@ def run_app():
                                                               weak_values_all_left_imag=weak_values_all_left_imag,
                                                               weak_values_all_right_imag=weak_values_all_right_imag,
                                                               show_plot=show_plot)
-
     submit = request.args.get('submit')
     #
     # print(f"submit: {submit}")
@@ -111,11 +112,19 @@ def run_app():
     )
 
 
-@app.route('/plot')
+@app.route('/plot/')
 def plot():
-    return stream_template(
-        "plot.html",
-        title="Weak Values Plot")
+    # return render_template(
+    #     "plot.html",
+    #     title="Weak Values Plot")
+
+    # use when opening the file from the web server only
+    plot_file = open(os.getcwd() + "templates/plot.html", "r+", encoding="utf-8")
+
+    # use when opening the file from the local server only
+    # plot_file = open("templates/plot.html", "r+", encoding="utf-8")
+
+    return ''.join(plot_file.readlines())
 
 
 @app.route('/about')

--- a/weak_values_GUI/templates/weak_values.html
+++ b/weak_values_GUI/templates/weak_values.html
@@ -200,7 +200,7 @@ radioButtons_i.forEach(function(radioButton) {
 function openNewPage() {
   var plotCheckbox = document.querySelector("input[name='show_plot']");
   if (plotCheckbox.checked) {
-      var newWindow = window.open("/plot", '_blank');
+      var newWindow = window.open("/plot/", '_blank');
       newWindow.focus(); // Optional: bring the new window to focus
       }
 }

--- a/weak_values_GUI/weak_values.py
+++ b/weak_values_GUI/weak_values.py
@@ -603,8 +603,10 @@ def plot_weak_values(weak_values_all_left: list = None,
             fig_p.add_trace(trace)
 
         fig_p.update_layout(margin=dict(l=0, r=0, b=0, t=0))
-        # fig_p.write_html(os.getcwd() + "/templates/plot.html", auto_open=False)  # Modify the html file with local server
-        fig_p.write_html(os.getcwd() + "/weak_values_GUI/templates/plot.html", auto_open=False)  # Modify the html file with web server
+
+        ### Important - comment/uncomment below 2 lines as needed per their own description ###
+        fig_p.write_html(os.getcwd() + "/templates/plot.html", auto_open=False)  # Modify the html file with local server
+        # fig_p.write_html(os.getcwd() + "/weak_values_GUI/templates/plot.html", auto_open=False)  # Modify the html file with web server
         # fig_p.show() #opens the file on the local server
 
     return weak_values_all_left_rot_x, weak_values_all_right_rot_x, final_rotated_values, ellipse_dict, is_ellipse


### PR DESCRIPTION
fixed opening plot by opening plot.html generated plotly as a file, reading the html content and converting it to text and then rendering the plot without `render_template()`